### PR TITLE
Ajout de css dans ocreply.json pour changer les couleurs des boutons créés

### DIFF
--- a/oc.js
+++ b/oc.js
@@ -92,7 +92,7 @@ function getMessageBySection() {
  * @param {any} answerObject
  */
 function addButton(answerObject) {
-    $submitFormButtton.before('<a class="btn btn-primary oc-moderation" style="float: right; margin: 10px 0 0 5px;" id="' + answerObject.id + '">' + answerObject.title + '</a>');
+    $submitFormButtton.before('<a class="btn btn-primary oc-moderation" style="float: right; margin: 10px 0 0 5px; border: 1px solid #380e00; box-shadow: inset 0 1px 1px 0 #a95f47; background-color: #691c02; background-image: linear-gradient(to bottom,#872403 0,#763019 49%,#691c02 50%,#421100 100%); text-shadow: 0 -1px 0 #1c181b;" id="' + answerObject.id + '">' + answerObject.title + '</a>');
 }
 
 function performAction(answerObject) {


### PR DESCRIPTION
Afin que les boutons ajoutés pas le script ne créent pas de confusion avec les boutons originaux d'OC,  j'ai ajouté du css dans l'attribut style qui devrait modifier juste les couleurs des boutons créés sant toucher aux autres.
Le code css est directement repris de celui du site avec juste de nouvelles valeurs hex couleurs.
Aperçu s:
[Image](https://i.imgur.com/dhvnZwa.png)
[Code](https://codepen.io/anon/pen/RjgbpP)